### PR TITLE
Fix default certs paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # census-rm-monitoring
-Monitoring tools and scripts for the census RM services
+Monitoring tools and scripts for the census RM services, migrated from [census-rm-toolbox](https://github.com/ONSdigital/census-rm-toolbox/).

--- a/config.py
+++ b/config.py
@@ -17,6 +17,6 @@ class Config:
     DB_NAME = os.getenv('DB_NAME', 'postgres')
     DB_USESSL = os.getenv('DB_USESSL', '')
     DB_ACTION_CERTIFICATES = os.getenv('DB_ACTION_CERTIFICATES',
-                                       (" sslmode=verify-ca sslrootcert=/home/toolbox/.postgresql-action/root.crt "
-                                        "sslcert=/home/toolbox/.postgresql-action/postgresql.crt "
-                                        "sslkey=/home/toolbox/.postgresql-action/postgresql.key"))
+                                       (" sslmode=verify-ca sslrootcert=/home/monitoring/.postgresql-action/root.crt "
+                                        "sslcert=/home/monitoring/.postgresql-action/postgresql.crt "
+                                        "sslkey=/home/monitoring/.postgresql-action/postgresql.key"))


### PR DESCRIPTION
# Motivation and Context
The default certs paths were hardcoded for the toolbox image, update them to work for the monitoring image.

# What has changed
* Update hardcoded certs paths

# How to test?
Check the certs paths are valid for this repos image

# Links
https://trello.com/c/XHfzQUze/1257-split-cloudshell-utilities-and-monitoring-tools-out-of-census-rm-toolbox
