### PR TITLE
Add fulfilment to process count

### DIFF
--- a/monitoring/action_worker_database_monitor.py
+++ b/monitoring/action_worker_database_monitor.py
@@ -4,8 +4,10 @@ from config import Config
 from utilities.db_helper import execute_sql_query
 
 if __name__ == "__main__":
-    sql_query = 'SELECT COUNT(*) FROM actionv2.case_to_process;'
-
-    db_result = execute_sql_query(sql_query, Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
-
-    print(json.dumps({'case_to_process_count': db_result[0][0]}))
+    case_to_process_count = 'SELECT COUNT(*) FROM actionv2.case_to_process;'
+    case_to_process_count_result = execute_sql_query(case_to_process_count, Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
+    print(json.dumps({'case_to_process_count': case_to_process_count_result[0][0]}))
+    
+    fulfilment_to_process_count = 'SELECT COUNT(*) FROM actionv2.fulfilment_to_process;'
+    fulfilment_to_process_count_result = execute_sql_query(fulfilment_to_process_count, Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
+    print(json.dumps({'fulfilment_to_process_count': fulfilment_to_process_count_result[0][0]}))

--- a/monitoring/action_worker_database_monitor.py
+++ b/monitoring/action_worker_database_monitor.py
@@ -5,9 +5,11 @@ from utilities.db_helper import execute_sql_query
 
 if __name__ == "__main__":
     case_to_process_count = 'SELECT COUNT(*) FROM actionv2.case_to_process;'
-    case_to_process_count_result = execute_sql_query(case_to_process_count, Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
+    case_to_process_count_result = execute_sql_query(case_to_process_count,
+                                                     Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
     print(json.dumps({'case_to_process_count': case_to_process_count_result[0][0]}))
-    
+
     fulfilment_to_process_count = 'SELECT COUNT(*) FROM actionv2.fulfilment_to_process;'
-    fulfilment_to_process_count_result = execute_sql_query(fulfilment_to_process_count, Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
+    fulfilment_to_process_count_result = execute_sql_query(fulfilment_to_process_count,
+                                                           Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
     print(json.dumps({'fulfilment_to_process_count': fulfilment_to_process_count_result[0][0]}))


### PR DESCRIPTION
# Motivation and Context
We need to keep a close eye on the volume of inbound fulfilments, monitoring the fulfilment to process table in the same way we do case to process gives us good insight into both the volume of incoming requests and the speed the action workers process them overnight.

# What has changed
* Add fulfilment to process count to action DB monitor

# How to test?
Check the query is valid.

# Links
https://trello.com/c/VG71U98U/1976-add-fulfilment-to-process-count-logging-and-metric
