### PR TITLE
updated metric to print fulfilment type count

### DIFF
--- a/monitoring/action_worker_database_monitor.py
+++ b/monitoring/action_worker_database_monitor.py
@@ -9,7 +9,12 @@ if __name__ == "__main__":
                                                      Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
     print(json.dumps({'case_to_process_count': case_to_process_count_result[0][0]}))
 
-    fulfilment_to_process_count = 'SELECT COUNT(*) FROM actionv2.fulfilment_to_process;'
+    fulfilment_to_process_count = 'SELECT fulfilment_code, COUNT(*) FROM actionv2.fulfilment_to_process group by fulfilment_code;'
     fulfilment_to_process_count_result = execute_sql_query(fulfilment_to_process_count,
                                                            Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
-    print(json.dumps({'fulfilment_to_process_count': fulfilment_to_process_count_result[0][0]}))
+    fulfilment_dict = dict(fulfilment_to_process_count_result)
+    total_count = sum(fulfilment_dict.values())
+    fulfilments = fulfilment_to_process_count_result
+    print(json.dumps({'fulfilment_to_process_count': total_count}))
+    for fulfilment, count in fulfilment_dict.items():
+        print(json.dumps({'fulfilment': fulfilment, 'fulfilment_count': count}))

--- a/monitoring/action_worker_database_monitor.py
+++ b/monitoring/action_worker_database_monitor.py
@@ -9,12 +9,12 @@ if __name__ == "__main__":
                                                      Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
     print(json.dumps({'case_to_process_count': case_to_process_count_result[0][0]}))
 
-    fulfilment_to_process_count = 'SELECT fulfilment_code, COUNT(*) FROM actionv2.fulfilment_to_process group by fulfilment_code;'
+    fulfilment_to_process_count = 'SELECT fulfilment_code, COUNT(*) FROM actionv2.fulfilment_to_process ' \
+                                  'group by fulfilment_code;'
     fulfilment_to_process_count_result = execute_sql_query(fulfilment_to_process_count,
                                                            Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES)
     fulfilment_dict = dict(fulfilment_to_process_count_result)
     total_count = sum(fulfilment_dict.values())
-    fulfilments = fulfilment_to_process_count_result
     print(json.dumps({'fulfilment_to_process_count': total_count}))
     for fulfilment, count in fulfilment_dict.items():
         print(json.dumps({'fulfilment': fulfilment, 'fulfilment_count': count}))


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to be able to monitor throughout the day how many fulfilments we have per pack code. 

# What has changed
<!--- What manifest changes have been made? -->
- Updated the fulfilment_to_process logs to now group by fulfilment code so we can monitor those.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
- Run in your GCP project or local docker. Should be able to get a nice sum of all fulfilments and each fulfilment types.
- Run with terraform PR and see if you can graph the fulfilments per pack code.
# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
[Trello](https://trello.com/c/gYY8edfT)
