### PR TITLE
2104 monitor for long running queries in dbs replicas

### DIFF
--- a/database_monitoring_logger.sh
+++ b/database_monitoring_logger.sh
@@ -2,5 +2,6 @@ while [ 1 ]
 do
     python -m monitoring.find_slow_event_processing
     python -m monitoring.action_worker_database_monitor
+    python -m monitoring.find_long_running_db_queries
     sleep 59s
 done

--- a/monitoring/find_long_running_db_queries.py
+++ b/monitoring/find_long_running_db_queries.py
@@ -6,7 +6,7 @@ from utilities.db_helper import execute_sql_query
 if __name__ == "__main__":
     long_running_query_check = """SELECT pid, age(clock_timestamp(), query_start), usename, query 
                                FROM pg_stat_activity 
-                               WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%' And usename != 'rmuser' 
+                               WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%' And query not like 'SET application_name%' 
                                ORDER BY query_start desc;"""
     case_result = execute_sql_query(long_running_query_check)
 

--- a/monitoring/find_long_running_db_queries.py
+++ b/monitoring/find_long_running_db_queries.py
@@ -4,9 +4,10 @@ from config import Config
 from utilities.db_helper import execute_sql_query
 
 if __name__ == "__main__":
-    long_running_query_check = """SELECT pid, age(clock_timestamp(), query_start), usename, query 
-                               FROM pg_stat_activity 
-                               WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%' And query not like 'SET application_name%' 
+    long_running_query_check = """SELECT pid, age(clock_timestamp(), query_start), usename, query
+                               FROM pg_stat_activity
+                               WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%'
+                               And query not like 'SET application_name%'
                                ORDER BY query_start desc;"""
     case_result = execute_sql_query(long_running_query_check)
 

--- a/monitoring/find_long_running_db_queries.py
+++ b/monitoring/find_long_running_db_queries.py
@@ -1,0 +1,28 @@
+import json
+
+from config import Config
+from utilities.db_helper import execute_sql_query
+
+if __name__ == "__main__":
+    long_running_query_check = """SELECT pid, age(clock_timestamp(), query_start), usename, query 
+                               FROM pg_stat_activity 
+                               WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%' And usename != 'rmuser' 
+                               ORDER BY query_start desc;"""
+    case_result = execute_sql_query(long_running_query_check)
+
+    action_result = execute_sql_query(long_running_query_check, Config.DB_HOST_ACTION,
+                                      Config.DB_ACTION_CERTIFICATES)
+
+    for pid, age, usename, query in case_result:
+        if age:
+            print(json.dumps({'pid': pid, 'age': age.seconds, 'usename': usename, 'query': query, 'DB': 'Case'},
+                             default=str))
+        else:
+            print(json.dumps({'pid': pid, 'age': age, 'usename': usename, 'query': query, 'DB': 'Case'}, default=str))
+
+    for pid, age, usename, query in action_result:
+        if age:
+            print(json.dumps({'pid': pid, 'age': age.seconds, 'usename': usename, 'query': query, 'DB': 'Action'},
+                             default=str))
+        else:
+            print(json.dumps({'pid': pid, 'age': age, 'usename': usename, 'query': query, 'DB': 'Action'}, default=str))


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Added a script to find any long running queries in our DBs and replicas. This is added to the database monitor and I've created a metric to go along side it

# What has changed
<!--- What manifest changes have been made? -->
- Added a new script to find long running queries

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
- Run with terraform PR and create some long running queries. 
- Create a dashboard from the metric and set it to group by DB with an aggregator of `Max`. This should show you if theres any long running queries going over 60 seconds. Once the query has been terminated, the graph should go back down below 60 seconds

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
[Trello](https://trello.com/c/NQmjAR9O/2104-monitor-for-long-running-queries-in-dbs-replicas-5)