### PR TITLE
Stop counting duplicate receipts (e.g. PQRS)

### DIFF
--- a/monitoring/regional_counts.py
+++ b/monitoring/regional_counts.py
@@ -33,7 +33,7 @@ def get_response_events():
                WHEN 'N' THEN 'Northern Ireland Responses'
                ELSE 'Unknown Region Responses' || counts.region END,
            counts.region_count
-    FROM (SELECT LEFT(c.region,1) as region, COUNT(*) AS region_count
+    FROM (SELECT LEFT(c.region,1) as region, COUNT(distinct(q.qid)) AS region_count
           FROM casev2.event e, casev2.uac_qid_link q, casev2.cases c
           WHERE e.event_type='RESPONSE_RECEIVED' AND e.uac_qid_link_id = q.id
           AND q.active = 'f' AND q.caze_case_id = c.case_id

--- a/monitoring/regional_counts.py
+++ b/monitoring/regional_counts.py
@@ -33,12 +33,11 @@ def get_response_events():
                WHEN 'N' THEN 'Northern Ireland Responses'
                ELSE 'Unknown Region Responses' || counts.region END,
            counts.region_count
-    FROM (SELECT LEFT(c.region,1) as region, COUNT(distinct(q.qid)) AS region_count
-          FROM casev2.event e, casev2.uac_qid_link q, casev2.cases c
-          WHERE e.event_type='RESPONSE_RECEIVED' AND e.uac_qid_link_id = q.id
-          AND q.active = 'f' AND q.caze_case_id = c.case_id
+    FROM (SELECT LEFT(c.region,1) as region, COUNT(*) AS region_count
+          FROM casev2.uac_qid_link q, casev2.cases c
+          WHERE q.active = 'f' AND q.caze_case_id = c.case_id
           AND c.action_plan_id = 'c4415287-0e37-447b-9c3d-1a011c9fa3db' GROUP BY LEFT(c.region,1)) AS counts
-        """
+    """
 
     db_result = execute_sql_query(sql_query)
 


### PR DESCRIPTION
# Motivation and Context
We've found more than 4,000 duplicate PQRS receipts sent to RM from upstream. We should eliminate **all** duplicate receipts so that we only count receipted QIDs, instead of RESPONSE_RECEIVED events.

# What has changed
Made the query distinct on QID to get rid of dupes.

# How to test?
Try both the old SQL and the new SQL. When I tested it at 12:40pm the difference was approximately 52,000 (over-estimate of response rate) by the old SQL.

# Links
Trello: https://trello.com/c/lWS08tYp